### PR TITLE
إضافة سياسة الاسترداد إلى صفحة الشروط والأحكام

### DIFF
--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -76,6 +76,21 @@ export default function TermsAndConditions() {
             </div>
 
             <div className="space-y-4">
+              <h2 className="text-xl font-semibold">{t.refundPolicyTitle || "سياسة الاسترداد"}</h2>
+              <p className="text-muted-foreground">{t.refundPolicyText || "نحن نقدم سياسة استرداد عادلة لعملائنا."}</p>
+              <p className="text-muted-foreground">
+                {dir === "rtl"
+                  ? "يمكن للمشتركين طلب استرداد كامل خلال 14 يومًا من تاريخ الشراء إذا لم يكونوا راضين عن الخدمة لأي سبب من الأسباب. بعد فترة 14 يومًا، لا يمكن استرداد المدفوعات. لطلب استرداد، يرجى التواصل معنا عبر البريد الإلكتروني مع ذكر سبب طلب الاسترداد ومعلومات الحساب الخاصة بك."
+                  : "Subscribers can request a full refund within 14 days of purchase if they are not satisfied with the service for any reason. After the 14-day period, payments are non-refundable. To request a refund, please contact us via email with the reason for your refund request and your account information."}
+              </p>
+              <p className="text-muted-foreground">
+                {dir === "rtl"
+                  ? "في حالة الاشتراكات السنوية، يمكن للمشتركين طلب استرداد جزئي بناءً على المدة المتبقية من الاشتراك، مع خصم رسوم إدارية بنسبة 15%. نحتفظ بالحق في رفض طلبات الاسترداد إذا كان هناك دليل على إساءة استخدام الخدمة أو انتهاك شروط الاستخدام."
+                  : "For annual subscriptions, subscribers can request a partial refund based on the remaining subscription period, minus a 15% administrative fee. We reserve the right to refuse refund requests if there is evidence of service abuse or violation of the terms of use."}
+              </p>
+            </div>
+
+            <div className="space-y-4">
               <h2 className="text-xl font-semibold">{t.contactTitle}</h2>
               <p className="text-muted-foreground">{t.contactInfoTerms}</p>
               <p className="text-muted-foreground">

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -4,6 +4,10 @@ export type Translation = {
   appTitle: string
   appDescription: string
 
+  // Refund policy
+  refundPolicyTitle: string
+  refundPolicyText: string
+
   // Form labels
   itemName: string
   itemValue: string
@@ -364,6 +368,10 @@ export type Translation = {
 export const ar: Translation = {
   appTitle: "WorldCosts",
   appDescription: "احسب تكلفة منتجاتك بدقة وبعملات مختلفة مع إمكانية احتساب الشحن والضرائب والجمارك",
+
+  // Refund policy
+  refundPolicyTitle: "سياسة الاسترداد",
+  refundPolicyText: "نحن نقدم سياسة استرداد عادلة لعملائنا.",
 
   // Subscription related
   subscription: "الاشتراك",
@@ -729,6 +737,10 @@ export const ar: Translation = {
 export const en: Translation = {
   appTitle: "WorldCosts",
   appDescription: "Add items with currency selection and calculate totals in different currencies",
+
+  // Refund policy
+  refundPolicyTitle: "Refund Policy",
+  refundPolicyText: "We offer a fair refund policy for our customers.",
 
   // Subscription related
   subscription: "Subscription",
@@ -1096,6 +1108,10 @@ export const en: Translation = {
 export const de: Translation = {
   appTitle: "WorldCosts",
   appDescription: "Fügen Sie Artikel mit Währungsauswahl hinzu und berechnen Sie Summen in verschiedenen Währungen",
+
+  // Refund policy
+  refundPolicyTitle: "Rückerstattungsrichtlinie",
+  refundPolicyText: "Wir bieten eine faire Rückerstattungsrichtlinie für unsere Kunden.",
 
   // Subscription related
   subscription: "Abonnement",
@@ -1471,6 +1487,10 @@ export const de: Translation = {
 export const fr: Translation = {
   appTitle: "WorldCosts",
   appDescription: "Ajoutez des articles avec sélection de devise et calculez les totaux en différentes devises",
+
+  // Refund policy
+  refundPolicyTitle: "Politique de Remboursement",
+  refundPolicyText: "Nous offrons une politique de remboursement équitable pour nos clients.",
 
   // Subscription related
   subscription: "Abonnement",


### PR DESCRIPTION
هذا الطلب يضيف سياسة الاسترداد إلى صفحة الشروط والأحكام، وهو متطلب مهم للتحقق من موقع Paddle.

التغييرات:

1. إضافة قسم سياسة الاسترداد إلى صفحة الشروط والأحكام
2. إضافة ترجمات لعناوين ونصوص سياسة الاسترداد لجميع اللغات المدعومة

سياسة الاسترداد توضح أن المشتركين يمكنهم طلب استرداد كامل خلال 14 يومًا من تاريخ الشراء إذا لم يكونوا راضين عن الخدمة لأي سبب من الأسباب. بعد فترة 14 يومًا، لا يمكن استرداد المدفوعات.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author