### PR TITLE
إصلاح مشكلة تأكيد البريد الإلكتروني

### DIFF
--- a/app/auth/confirm/page.tsx
+++ b/app/auth/confirm/page.tsx
@@ -28,6 +28,19 @@ function ConfirmEmailContent() {
         const token = searchParams.get("token")
         const type = searchParams.get("type") || "signup"
 
+        // التحقق من وجود رمز الخطأ في URL
+        const error = searchParams.get("error")
+        const error_code = searchParams.get("error_code")
+        const error_description = searchParams.get("error_description")
+
+        // إذا كان هناك خطأ في URL، نعرضه للمستخدم
+        if (error) {
+          console.error("Error in URL:", { error, error_code, error_description })
+          setErrorMessage(error_description || error || t.emailConfirmationFailed || "فشل تأكيد البريد الإلكتروني")
+          setIsLoading(false)
+          return
+        }
+
         if (!token) {
           setErrorMessage(t.tokenRequired || "رمز التأكيد مطلوب")
           setIsLoading(false)
@@ -40,13 +53,13 @@ function ConfirmEmailContent() {
         if (type === "recovery") {
           // إعادة تعيين كلمة المرور
           result = await supabase.auth.verifyOtp({
-            token_hash: token,
+            token,
             type: "recovery",
           })
         } else {
           // تأكيد البريد الإلكتروني
           result = await supabase.auth.verifyOtp({
-            token_hash: token,
+            token,
             type: "email",
           })
         }


### PR DESCRIPTION
هذا الطلب يحتوي على إصلاح لمشكلة تأكيد البريد الإلكتروني عن طريق:

1. استخدام `token` بدلاً من `token_hash` في وظيفة `verifyOtp`
2. إضافة معالجة للأخطاء التي تأتي في URL

هذا سيساعد في حل مشكلة الخطأ `otp_expired` التي تظهر عند النقر على رابط تأكيد البريد الإلكتروني.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author